### PR TITLE
Open using both Conversation ID and Channel Key

### DIFF
--- a/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KommunicateFlutterPlugin.java
+++ b/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KommunicateFlutterPlugin.java
@@ -150,7 +150,7 @@ public class KommunicateFlutterPlugin implements MethodCallHandler {
                 @Override
                 public void onFailure(Exception e, Context context) {
                     try {
-                        Kommunicate.openConversation(context, Integer.valueOf(clientConversationId), new KmCallback() {
+                        KmConversationHelper.openConversation(context, true, Integer.valueOf(clientConversationId), new KmCallback() {
                             @Override
                             public void onSuccess(Object message) {
                                 result.success(message.toString());

--- a/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KommunicateFlutterPlugin.java
+++ b/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KommunicateFlutterPlugin.java
@@ -119,7 +119,7 @@ public class KommunicateFlutterPlugin implements MethodCallHandler {
                 }
             });
         } else if (call.method.equals("openParticularConversation")) {
-            String clientConversationId = (String) call.arguments;
+            final String clientConversationId = (String) call.arguments;
             if (TextUtils.isEmpty(clientConversationId)) {
                 result.error(ERROR, "Invalid or empty clientConversationId", null);
                 return;
@@ -149,7 +149,21 @@ public class KommunicateFlutterPlugin implements MethodCallHandler {
 
                 @Override
                 public void onFailure(Exception e, Context context) {
-                    result.error(ERROR, e != null ? e.getLocalizedMessage() : "Unable to open Conversation", null);
+                    try {
+                        Kommunicate.openConversation(context, Integer.valueOf(clientConversationId), new KmCallback() {
+                            @Override
+                            public void onSuccess(Object message) {
+                                result.success(message.toString());
+                            }
+
+                            @Override
+                            public void onFailure(Object error) {
+                                result.error(ERROR, error.toString(), null);
+                            }
+                        });
+                    } catch (NumberFormatException ex) {
+                        result.error(ERROR, "Invalid Conversation ID / Channel Key", null);
+                    }
                 }
             }).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
         } else if (call.method.equals("buildConversation")) {

--- a/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KommunicateFlutterPlugin.java
+++ b/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KommunicateFlutterPlugin.java
@@ -149,21 +149,31 @@ public class KommunicateFlutterPlugin implements MethodCallHandler {
 
                 @Override
                 public void onFailure(Exception e, Context context) {
-                    try {
-                        KmConversationHelper.openConversation(context, true, Integer.valueOf(clientConversationId), new KmCallback() {
-                            @Override
-                            public void onSuccess(Object message) {
-                                result.success(message.toString());
-                            }
+                    new KmConversationInfoTask(context, Integer.valueOf(clientConversationId), new KmGetConversationInfoCallback() {
+                        @Override
+                        public void onSuccess(Channel channel, Context context) {
+                            if (channel != null) {
 
-                            @Override
-                            public void onFailure(Object error) {
-                                result.error(ERROR, error.toString(), null);
+                                    Kommunicate.openConversation(context, channel.getKey(), new KmCallback() {
+                                        @Override
+                                        public void onSuccess(Object message) {
+                                            result.success(message.toString());
+                                        }
+
+                                        @Override
+                                        public void onFailure(Object error) {
+                                            result.error(ERROR, error.toString(), null);
+                                        }
+                                    });
+
                             }
-                        });
-                    } catch (NumberFormatException ex) {
-                        result.error(ERROR, "Invalid Conversation ID / Channel Key", null);
-                    }
+                        }
+
+                        @Override
+                        public void onFailure(Exception e, Context context) {
+                            result.error(ERROR, e.getMessage(), null);
+                        }
+                    }).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
                 }
             }).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
         } else if (call.method.equals("buildConversation")) {

--- a/ios/Classes/SwiftKommunicateFlutterPlugin.swift
+++ b/ios/Classes/SwiftKommunicateFlutterPlugin.swift
@@ -248,8 +248,19 @@ public class SwiftKommunicateFlutterPlugin: NSObject, FlutterPlugin, KMPreChatFo
     
     func openParticularConversation(_ conversationId: String,_ skipConversationList: Bool, _ callback: @escaping FlutterResult) -> Void {
         DispatchQueue.main.async{
+            let alChannelService = ALChannelService()
+            var conversationID = String()
+            if Int(conversationId) != nil {
+                alChannelService.getChannelInformation(NSNumber(value: Int(conversationId)!), orClientChannelKey: nil) { (channel) in
+                    if channel != nil && channel?.clientChannelKey != nil {
+                        conversationID = channel!.clientChannelKey
+                    }
+                }
+            } else {
+                conversationID = conversationId
+            }
             if let top = UIApplication.topViewController(){
-                Kommunicate.showConversationWith(groupId: conversationId, from: top, completionHandler: ({ (shown) in
+                Kommunicate.showConversationWith(groupId: conversationID, from: top, completionHandler: ({ (shown) in
                     if(shown){
                         callback(conversationId)
                     } else {
@@ -258,7 +269,8 @@ public class SwiftKommunicateFlutterPlugin: NSObject, FlutterPlugin, KMPreChatFo
                 }))
             } else {
                 self.sendErrorResultWithCallback(result: callback, message: "Failed to launch conversation with conversationId : " + conversationId)
-            }}
+            }
+        }
     }
     
     public func closeButtonTapped() {


### PR DESCRIPTION
Some customers are using Channel key to open the conversation, but flutter only supported opening conversation using Client Conversation ID.
Added support to open conversation using channel key using the same method.