### PR TITLE
[CM-846] - Support to change teamID of conversation - Android

### DIFF
--- a/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmMethodHandler.java
+++ b/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmMethodHandler.java
@@ -275,6 +275,25 @@ public class KmMethodHandler implements MethodCallHandler {
             } catch (Exception e) {
                 result.error(ERROR, e.toString(), null);
             }
+        } else if(call.method.equals("updateTeamId")) {
+            try {
+                    KmSettings.updateTeamId(context,
+                            call.hasArgument("conversationId")? (Integer) call.argument("conversationId") : null,
+                            call.hasArgument("clientConversationId")? (String) call.argument("clientConversationId") : null,
+                            (String) call.argument("teamId"),
+                            new KmCallback() {
+                                @Override
+                                public void onSuccess(Object o) {
+                                    result.success(o);
+                                }
+                                @Override
+                                public void onFailure(Object o) {
+                                    result.error(ERROR, o.toString(), null);
+                                }
+                            });
+            } catch(Exception e) {
+                result.error(ERROR, e.toString(), null);
+            }
         }
         else {
             result.notImplemented();

--- a/example/lib/home.dart
+++ b/example/lib/home.dart
@@ -180,6 +180,31 @@ class HomePageWidget extends StatelessWidget {
                 color: Color(0xff5c5aa7),
                 child: new MaterialButton(
                   onPressed: () {
+                    KommunicateFlutterPlugin.updateTeamId({
+                      //'conversationId': 70780495,
+                      'clientConversationId': '69360869',
+                      'teamId': '63641656'
+                    }).then((value) {
+                      print('team context updated' + value.toString());
+                    }).catchError((error) {
+                      print(
+                          'Error in updating team context' + error.toString());
+                    });
+                  },
+                  minWidth: 400,
+                  padding: EdgeInsets.fromLTRB(20.0, 15.0, 20.0, 15.0),
+                  child: Text("Update team",
+                      textAlign: TextAlign.center,
+                      style: style.copyWith(
+                          color: Colors.white, fontWeight: FontWeight.bold)),
+                )),
+            SizedBox(height: 10),
+            new Material(
+                elevation: 5.0,
+                borderRadius: BorderRadius.circular(30.0),
+                color: Color(0xff5c5aa7),
+                child: new MaterialButton(
+                  onPressed: () {
                     KommunicateFlutterPlugin.updateUserDetail({
                       'displayName':
                           "FUser-" + getCurrentTime() + "-" + getPlatformName(),

--- a/lib/kommunicate_flutter.dart
+++ b/lib/kommunicate_flutter.dart
@@ -56,4 +56,8 @@ class KommunicateFlutterPlugin {
   static Future<dynamic> fetchUserDetails(String userid) async {
     return await _channel.invokeMethod('fetchUserDetails', userid);
   }
+
+  static Future<dynamic> updateTeamId(dynamic conversationObject) async {
+    return await _channel.invokeMethod('updateTeamId', conversationObject);
+  }
 }


### PR DESCRIPTION
```
KommunicateFlutterPlugin.updateTeamId({
                      //'conversationId': 70780495,
                      'clientConversationId': '69360869',
                      'teamId': '63641656'
                    })
```

We can pass either conversationID (integer) or clientConversationID (string) in the object.

