### PR TITLE
[CM-940] - Display name not accepting spaces

### DIFF
--- a/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmMethodHandler.java
+++ b/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmMethodHandler.java
@@ -37,7 +37,7 @@ import com.applozic.mobicomkit.api.conversation.AlTotalUnreadCountTask;
 
 import java.util.HashMap;
 import java.util.Map;
-
+import org.json.JSONObject;
 /**
  * KommunicateFlutterPlugin
  */
@@ -62,10 +62,11 @@ public class KmMethodHandler implements MethodCallHandler {
             result.success(Kommunicate.isLoggedIn(context));
         } else if (call.method.equals("login")) {
             try {
-                KMUser user = (KMUser) GsonUtils.getObjectFromJson(call.arguments.toString(), KMUser.class);
+                JSONObject userObject = new JSONObject(call.arguments.toString());
+                KMUser user = (KMUser) GsonUtils.getObjectFromJson(userObject.toString(), KMUser.class);
 
-                if (call.hasArgument("appId") && !TextUtils.isEmpty((String) call.argument("appId"))) {
-                    Kommunicate.init(context, (String) call.argument("appId"));
+                if (userObject.has("appId") && !TextUtils.isEmpty(userObject.get("appId").toString())) {
+                    Kommunicate.init(context, userObject.get("appId").toString());
                 } else {
                     result.error(ERROR, "appId is missing", null);
                     return;

--- a/ios/Classes/SwiftKommunicateFlutterPlugin.swift
+++ b/ios/Classes/SwiftKommunicateFlutterPlugin.swift
@@ -530,5 +530,4 @@ extension String {
              }
              return nil
          }
-
 }

--- a/ios/Classes/SwiftKommunicateFlutterPlugin.swift
+++ b/ios/Classes/SwiftKommunicateFlutterPlugin.swift
@@ -37,18 +37,16 @@ public class SwiftKommunicateFlutterPlugin: NSObject, FlutterPlugin, KMPreChatFo
         } else if(call.method == "isLoggedIn") {
             result(Kommunicate.isLoggedIn)
         } else if(call.method == "login") {
-            guard var userDict = call.arguments as? Dictionary<String, Any> else {
+            guard let jsonString = call.arguments as? String, var userDict = jsonString.convertToDictionary() else {
                 self.sendErrorResultWithCallback(result: result, message: "Unable to parse user JSON")
                 return
             }
-            
+
             guard let appId = userDict["appId"] as? String, !appId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
                 self.sendErrorResultWithCallback(result: result, message: "Invalid or missing appId")
                 return
             }
-            
             Kommunicate.setup(applicationId: appId)
-            
             userDict.removeValue(forKey: "appId")
             
             do {
@@ -525,3 +523,12 @@ extension UIApplication {
         }
         return controller
     }}
+extension String {
+    func convertToDictionary() -> [String: Any]? {
+             if let data = data(using: .utf8) {
+                 return try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+             }
+             return nil
+         }
+
+}

--- a/lib/kommunicate_flutter.dart
+++ b/lib/kommunicate_flutter.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-
+import 'dart:convert';
 import 'package:flutter/services.dart';
 
 class KommunicateFlutterPlugin {
@@ -28,7 +28,7 @@ class KommunicateFlutterPlugin {
   }
 
   static Future<dynamic> login(dynamic kmUser) async {
-    return await _channel.invokeMethod('login', kmUser);
+    return await _channel.invokeMethod('login', jsonEncode(kmUser));
   }
 
   static Future<dynamic> loginAsVisitor(String appId) async {


### PR DESCRIPTION
## Cause of issue:
- When dynamic object was passed from Flutter to Native SDK, the space in display name was getting treated as a non-breaking space, which was throwing a JSONException. 
## Fix:
 - We are doing jsonEncode() to the dynamic object before passing to Native SDK which sends the correct JSON data, along with spaces. With this fix, existing customers will not be affected. 