### PR TITLE
[CM-974] - Expose updateDefaultSetting method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
+## 1.4.8
+
+- added hideChatListOnNotification method 
+- updated iOS SDK to 6.7.0
+
 ## 1.4.7
 
 - Display Name accepting spaces now
 - Upgraded Android SDK version to 2.4.1
 
-- ## 1.4.6
+## 1.4.6
 
 - postBackToBotPlatform fix
 - upgrade Android version to 2.4.0

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Refer to the official docs here: https://docs.kommunicate.io/docs/flutter-instal
 ```
 dependencies:
   //other dependencies
-  kommunicate_flutter: ^1.4.7
+  kommunicate_flutter: ^1.4.8
 ```
 
 2. Install the package as below:

--- a/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmMethodHandler.java
+++ b/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmMethodHandler.java
@@ -22,6 +22,7 @@ import io.kommunicate.users.KMUser;
 import io.kommunicate.KmConversationHelper;
 import io.kommunicate.KmException;
 
+import com.applozic.mobicomkit.ApplozicClient;
 import com.applozic.mobicomkit.api.account.user.AlUserUpdateTask;
 import com.applozic.mobicomkit.api.conversation.database.MessageDatabaseService;
 import com.applozic.mobicomkit.channel.service.ChannelService;
@@ -324,6 +325,13 @@ public class KmMethodHandler implements MethodCallHandler {
                     result.error(ERROR, "User not authorised. This usually happens when calling the function before conversationBuilder or loginUser. Make sure you call either of the two functions before updating the chatContext", null);
 
                 }
+            } catch(Exception e) {
+                result.error(ERROR, e.toString(), null);
+            }
+        } else if(call.method.equals("hideChatListOnNotification")) {
+            try {
+                ApplozicClient.getInstance(context).hideChatListOnNotification();
+                result.success(SUCCESS);
             } catch(Exception e) {
                 result.error(ERROR, e.toString(), null);
             }

--- a/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmMethodHandler.java
+++ b/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmMethodHandler.java
@@ -4,6 +4,8 @@ import android.app.Activity;
 import android.content.Context;
 import android.os.AsyncTask;
 import android.text.TextUtils;
+import java.util.List;
+import java.util.ArrayList;
 
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -331,6 +333,37 @@ public class KmMethodHandler implements MethodCallHandler {
         } else if(call.method.equals("hideChatListOnNotification")) {
             try {
                 ApplozicClient.getInstance(context).hideChatListOnNotification();
+                result.success(SUCCESS);
+            } catch(Exception e) {
+                result.error(ERROR, e.toString(), null);
+            }
+        } else if(call.method.equals("updateDefaultSetting")) {
+            try {
+                KmSettings.clearDefaultSettings();
+                JSONObject settingObject = new JSONObject(call.arguments.toString());
+                if (settingObject.has("defaultAgentIds") && !TextUtils.isEmpty(settingObject.get("defaultAgentIds").toString())) {
+                    List<String> agentList = new ArrayList<String>();
+                    for(int i = 0; i < settingObject.getJSONArray("defaultAgentIds").length(); i++){
+                        agentList.add(settingObject.getJSONArray("defaultAgentIds").get(i).toString());
+                    }
+                    KmSettings.setDefaultAgentIds(agentList);
+                }
+                if (settingObject.has("defaultBotIds") && !TextUtils.isEmpty(settingObject.get("defaultBotIds").toString())) {
+                    List<String> botList = new ArrayList<String>();
+                    for(int i = 0; i < settingObject.getJSONArray("defaultBotIds").length(); i++){
+                        botList.add(settingObject.getJSONArray("defaultBotIds").get(i).toString());
+                    }
+                    KmSettings.setDefaultBotIds(botList);
+                }
+                if (settingObject.has("defaultAssignee") && !TextUtils.isEmpty(settingObject.get("defaultAssignee").toString())) {
+                    KmSettings.setDefaultAssignee(settingObject.get("defaultAssignee").toString());
+                }
+                if (settingObject.has("teamId")) {
+                    KmSettings.setDefaultTeamId(settingObject.get("teamId").toString());
+                }
+                if (settingObject.has("skipRouting")) {
+                    KmSettings.setSkipRouting(true);
+                }
                 result.success(SUCCESS);
             } catch(Exception e) {
                 result.error(ERROR, e.toString(), null);

--- a/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmMethodHandler.java
+++ b/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmMethodHandler.java
@@ -362,7 +362,7 @@ public class KmMethodHandler implements MethodCallHandler {
                     KmSettings.setDefaultTeamId(settingObject.get("teamId").toString());
                 }
                 if (settingObject.has("skipRouting")) {
-                    KmSettings.setSkipRouting(true);
+                    KmSettings.setSkipRouting(Boolean.valueOf(settingObject.get("skipRouting").toString()));
                 }
                 result.success(SUCCESS);
             } catch(Exception e) {

--- a/ios/Classes/SwiftKommunicateFlutterPlugin.swift
+++ b/ios/Classes/SwiftKommunicateFlutterPlugin.swift
@@ -2,6 +2,7 @@ import Flutter
 import UIKit
 import Kommunicate
 import KommunicateCore_iOS_SDK
+import KommunicateChatUI_iOS_SDK
 
 public class SwiftKommunicateFlutterPlugin: NSObject, FlutterPlugin, KMPreChatFormViewControllerDelegate {
     var appId : String? = nil;
@@ -287,6 +288,9 @@ public class SwiftKommunicateFlutterPlugin: NSObject, FlutterPlugin, KMPreChatFo
             }
         } else if(call.method == "unreadCount") {
             result(ALUserService().getTotalUnreadCount()?.stringValue)
+        } else if(call.method == "hideChatListOnNotification") {
+            KMPushNotificationHandler.hideChatListOnNotification = true
+            result(String("Chat list hidden on Notification"))
         } else {
             result(FlutterMethodNotImplemented)
         }

--- a/ios/kommunicate_flutter.podspec
+++ b/ios/kommunicate_flutter.podspec
@@ -17,7 +17,7 @@ Flutter plugin for Kommunicate live chat.
 
   s.dependency 'Flutter'
   s.swift_version = '5.1'
-  s.dependency 'Kommunicate', '~> 6.6.0'
+  s.dependency 'Kommunicate', '~> 6.7.0'
 
   s.ios.deployment_target = '12.0'
 end

--- a/lib/kommunicate_flutter.dart
+++ b/lib/kommunicate_flutter.dart
@@ -60,4 +60,8 @@ class KommunicateFlutterPlugin {
   static Future<dynamic> updateTeamId(dynamic conversationObject) async {
     return await _channel.invokeMethod('updateTeamId', conversationObject);
   }
+  
+  static Future<dynamic> hideChatListOnNotification() async {
+    return await _channel.invokeMethod('hideChatListOnNotification');
+  }
 }

--- a/lib/kommunicate_flutter.dart
+++ b/lib/kommunicate_flutter.dart
@@ -64,4 +64,7 @@ class KommunicateFlutterPlugin {
   static Future<dynamic> hideChatListOnNotification() async {
     return await _channel.invokeMethod('hideChatListOnNotification');
   }
+  static Future<dynamic> updateDefaultSetting(dynamic defaultSetting) async {
+    return await _channel.invokeMethod('updateDefaultSetting', jsonEncode(defaultSetting));
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kommunicate_flutter
 description: Flutter plugin for Kommunicate live chat. Kommunicate provides open source live chat SDK in android. The Kommunicate SDK is flexible, lightweight and easily integrable.
-version: 1.4.7
+version: 1.4.8
 homepage: https://kommunicate.io
 
 environment:


### PR DESCRIPTION
## What do you want to achieve?
- updateDefaultSetting method is available in Android and iOS, which changes the default setting of a conversation.
- When "Start new Conversation"  is clicked from conversation list screen then these settings are used.
- Exposed a method "updateDefaultSetting" which would update the setting for both Android and iOS.

## How to implement:
- Pass a dynamic setting object to "KommunicateFlutterPlugin.updateDefaultSetting" which contains the setting to be passed.

## Flutter dart code:
```dart
dynamic setting = {
      "defaultAgentIds": ["amantoppo3199@gmail.com", "amantoppo@kommunicate.io"], //list of agentID
      "defaultBotIds": ["bot-e8xil"], // list of BotID
      "defaultAssignee": "amantoppo3199@gmail.com", 
      "skipRouting": true,
      "teamId": "63773459"
      };
KommunicateFlutterPlugin.updateDefaultSetting(setting)
```

### Other changes in the PR:
- hideChatListOnNotification was requested by a customer which hides the chat list when app opens from notification. Code was available for Android and IOS, exposed it to Flutter

