### PR TITLE
[CM-1119] - add support for Events - Android

### DIFF
--- a/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmEventListener.java
+++ b/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmEventListener.java
@@ -1,0 +1,102 @@
+package io.kommunicate.kommunicate_flutter_plugin;
+
+import com.applozic.mobicomkit.broadcast.AlEventManager;
+import io.kommunicate.callbacks.KmPluginEventListener;
+import com.applozic.mobicomkit.api.conversation.Message;
+import io.flutter.plugin.common.MethodChannel;
+import com.applozic.mobicommons.json.GsonUtils;
+import org.json.JSONObject;
+import org.json.JSONException;
+
+
+
+
+public class KmEventListener implements KmPluginEventListener {
+    private MethodChannel methodChannel;
+
+   public void register(MethodChannel methodChannel) {
+    this.methodChannel = methodChannel;
+        AlEventManager.getInstance().registerPluginEventListener(this);
+    }
+
+    public void unregister() {
+        AlEventManager.getInstance().unregisterPluginEventListener();
+    }
+
+    @Override
+    public void onPluginLaunch() {
+        methodChannel.invokeMethod("onPluginLaunch", "launch");
+
+    }
+
+    @Override
+    public void onPluginDismiss() {
+        methodChannel.invokeMethod("onPluginDismiss", "dismiss");
+
+    }
+
+    @Override
+    public void onConversationResolved(Integer conversationId) {
+        methodChannel.invokeMethod("onConversationResolved", conversationId);
+
+    }
+
+    @Override
+    public void onConversationRestarted(Integer conversationId) {
+        methodChannel.invokeMethod("onConversationRestarted", conversationId);
+
+    }
+
+    @Override
+    public void onRichMessageButtonClick(Integer conversationId, String actionType, Object action) {
+        try  {
+        JSONObject messageActionObject = new JSONObject();
+        messageActionObject.put("conversationId", conversationId);
+        messageActionObject.put("actionType", actionType);
+        messageActionObject.put("action", action);
+        methodChannel.invokeMethod("onRichMessageButtonClick", String.valueOf(messageActionObject));
+        } catch(JSONException e) {
+            
+        }
+
+    }
+
+    @Override
+    public void onStartNewConversation(Integer conversationId) {
+        methodChannel.invokeMethod("onStartNewConversation", conversationId);
+
+        
+    }
+
+    @Override
+    public void onSubmitRatingClick(Integer conversationId, Integer rating, String feedback) {
+        try {
+        JSONObject ratingObject = new JSONObject();
+        ratingObject.put("conversationId", conversationId);
+        ratingObject.put("rating", rating);
+        ratingObject.put("feedback", feedback);
+        methodChannel.invokeMethod("onSubmitRatingClick", String.valueOf(ratingObject));
+        } catch(JSONException e) {
+
+        }
+
+    }
+
+    @Override
+    public void onMessageSent(Message message) {
+        methodChannel.invokeMethod("onMessageSent", GsonUtils.getJsonFromObject(message, Message.class));
+
+    }
+
+    @Override
+    public void onMessageReceived(Message message) {
+        methodChannel.invokeMethod("onMessageReceived", GsonUtils.getJsonFromObject(message, Message.class));
+
+    }
+
+    @Override
+    public void onBackButtonClicked(boolean isConversationOpened) {
+        methodChannel.invokeMethod("onBackButtonClicked", isConversationOpened);
+
+    }
+}

--- a/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmEventListener.java
+++ b/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmEventListener.java
@@ -26,77 +26,68 @@ public class KmEventListener implements KmPluginEventListener {
     @Override
     public void onPluginLaunch() {
         methodChannel.invokeMethod("onPluginLaunch", "launch");
-
     }
 
     @Override
     public void onPluginDismiss() {
         methodChannel.invokeMethod("onPluginDismiss", "dismiss");
-
     }
 
     @Override
     public void onConversationResolved(Integer conversationId) {
         methodChannel.invokeMethod("onConversationResolved", conversationId);
-
     }
 
     @Override
     public void onConversationRestarted(Integer conversationId) {
         methodChannel.invokeMethod("onConversationRestarted", conversationId);
-
     }
 
     @Override
     public void onRichMessageButtonClick(Integer conversationId, String actionType, Object action) {
         try  {
-        JSONObject messageActionObject = new JSONObject();
-        messageActionObject.put("conversationId", conversationId);
-        messageActionObject.put("actionType", actionType);
-        messageActionObject.put("action", action);
-        methodChannel.invokeMethod("onRichMessageButtonClick", String.valueOf(messageActionObject));
+            JSONObject messageActionObject = new JSONObject();
+            messageActionObject.put("conversationId", conversationId);
+            messageActionObject.put("actionType", actionType);
+            messageActionObject.put("action", action);
+            methodChannel.invokeMethod("onRichMessageButtonClick", String.valueOf(messageActionObject));
         } catch(JSONException e) {
-            
+            methodChannel.invokeMethod("onRichMessageButtonClick", "error fetching data");
+            e.printStackTrace();
         }
-
     }
 
     @Override
     public void onStartNewConversation(Integer conversationId) {
         methodChannel.invokeMethod("onStartNewConversation", conversationId);
-
-        
     }
 
     @Override
     public void onSubmitRatingClick(Integer conversationId, Integer rating, String feedback) {
         try {
-        JSONObject ratingObject = new JSONObject();
-        ratingObject.put("conversationId", conversationId);
-        ratingObject.put("rating", rating);
-        ratingObject.put("feedback", feedback);
-        methodChannel.invokeMethod("onSubmitRatingClick", String.valueOf(ratingObject));
+            JSONObject ratingObject = new JSONObject();
+            ratingObject.put("conversationId", conversationId);
+            ratingObject.put("rating", rating);
+            ratingObject.put("feedback", feedback);
+            methodChannel.invokeMethod("onSubmitRatingClick", String.valueOf(ratingObject));
         } catch(JSONException e) {
-
+            methodChannel.invokeMethod("onSubmitRatingClick", "error fetching data");
+            e.printStackTrace();
         }
-
     }
 
     @Override
     public void onMessageSent(Message message) {
         methodChannel.invokeMethod("onMessageSent", GsonUtils.getJsonFromObject(message, Message.class));
-
     }
 
     @Override
     public void onMessageReceived(Message message) {
         methodChannel.invokeMethod("onMessageReceived", GsonUtils.getJsonFromObject(message, Message.class));
-
     }
 
     @Override
     public void onBackButtonClicked(boolean isConversationOpened) {
         methodChannel.invokeMethod("onBackButtonClicked", isConversationOpened);
-
     }
 }

--- a/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KommunicateFlutterPlugin.java
+++ b/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KommunicateFlutterPlugin.java
@@ -13,19 +13,24 @@ import io.flutter.plugin.common.PluginRegistry.Registrar;
 
             private MethodChannel methodChannel;
             private BinaryMessenger binaryMessenger;
+            private KmEventListener kmEventListener;
             public static void registerWith(Registrar registrar) {
                 final MethodChannel channel = new MethodChannel(registrar.messenger(), "kommunicate_flutter");
                 channel.setMethodCallHandler(new KmMethodHandler(registrar.activity()));
+                new KmEventListener().register(channel);
             }
 
             public void setupChannel(Activity context) {
                 methodChannel = new MethodChannel(binaryMessenger, "kommunicate_flutter");
                 methodChannel.setMethodCallHandler(new KmMethodHandler(context));
+                kmEventListener = new KmEventListener();
+                kmEventListener.register(methodChannel);                
             }
 
             private void destroyChannel() {
                 methodChannel.setMethodCallHandler(null);
                 methodChannel = null;
+                kmEventListener.unregister(); 
             }
 
             @Override

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'package:kommunicate_flutter/kommunicate_flutter.dart';
 import 'package:kommunicate_flutter_plugin_example/AppConfig.dart';
@@ -12,10 +13,34 @@ class MyApp extends StatefulWidget {
   @override
   _MyAppState createState() => _MyAppState();
 }
+// ignore: non_constant_identifier_names
+//KommunicateFlutterPlugin.registerEventListener();
+MethodChannel channel = MethodChannel('kommunicate_flutter');
 
 class _MyAppState extends State<MyApp> {
   @override
   void initState() {
+    print("start");
+    channel.setMethodCallHandler((call){
+      print("callhappens");
+      if(call.method == 'onPluginLaunch'){
+        print(call.arguments);
+      } else if(call.method == 'onPluginDismiss'){
+        print(call.arguments);
+      } else if(call.method == 'onConversationResolved'){
+        print(call.arguments);
+      } else if(call.method == 'onConversationRestarted'){
+        print(call.arguments);
+      } else if(call.method == 'onRichMessageButtonClick'){
+        print(call.arguments);
+      } else if(call.method == 'onStartNewConversation'){
+        print(call.arguments);
+      } else if(call.method == 'onMessageSent'){
+        print(call.arguments);
+      } 
+
+      return null;
+    });
     super.initState();
   }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -13,16 +13,13 @@ class MyApp extends StatefulWidget {
   @override
   _MyAppState createState() => _MyAppState();
 }
-// ignore: non_constant_identifier_names
-//KommunicateFlutterPlugin.registerEventListener();
+
 MethodChannel channel = MethodChannel('kommunicate_flutter');
 
 class _MyAppState extends State<MyApp> {
   @override
   void initState() {
-    print("start");
     channel.setMethodCallHandler((call){
-      print("callhappens");
       if(call.method == 'onPluginLaunch'){
         print(call.arguments);
       } else if(call.method == 'onPluginDismiss'){


### PR DESCRIPTION
## Issue: 
- To use events, customers had to use Native Android and iOS Code. 
- We have added the support to listen to events directly in Flutter.

## How to implement?
- In Dart code, we need to create a Method Channel - "kommunicate_flutter"
- This will give us setMethodCallHandler which returns all the events which we send from Native code. 

## Sample Code:

```dart
MethodChannel channel = MethodChannel('kommunicate_flutter');

channel.setMethodCallHandler((call){
      if(call.method == 'onPluginLaunch'){
        print(call.arguments);
      } else if(call.method == 'onPluginDismiss'){
        print(call.arguments);
      } else if(call.method == 'onConversationResolved'){
        print(call.arguments);
      } else if(call.method == 'onConversationRestarted'){
        print(call.arguments);
      } else if(call.method == 'onRichMessageButtonClick'){
        print(call.arguments);
      } else if(call.method == 'onStartNewConversation'){
        print(call.arguments);
      } else if(call.method == 'onMessageSent'){
        print(call.arguments);
      } 

      return null;
    });
```

-- This PR is for Android events  only. Will be creating a separate PR for IOS events.

