### PR TITLE
release changes for v1.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 1.5.5
+- Added support to send platform flag for analytics
+- Added logout option on conversation screen - Android
+- Handle Notifications from FCM directly - Android
+- Added support for AES256 encryption and decryption - Android
+- Added fix for API <= 19. Current min SDK version is still 16. All bugs have been fixed for lower SDK versions.
+- Added Edit Message Text box Customization - "messageEditTextBackgroundColor" - Android
+- Added support to set Custom bot name through Chat Context
+- Added Support for Android API 33 
+- Threads optimized and multiple crash fixed - Android
+- Added Support for App Extension - iOS
+- Fixed add contact permission to info.list issue when app is submitted on App Store - iOS
+- Added Button to create new conversation on conversation list screen - iOS 
+
+
 ## 1.5.1
 
 - Added Support for Android API 33 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Refer to the official docs here: https://docs.kommunicate.io/docs/flutter-instal
 ```
 dependencies:
   //other dependencies
-  kommunicate_flutter: ^1.5.1
+  kommunicate_flutter: ^1.5.5
 ```
 
 2. Install the package as below:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 16
@@ -38,5 +38,5 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    api 'io.kommunicate.sdk:kommunicateui:2.5.1'
+    api 'io.kommunicate.sdk:kommunicateui:2.6.2'
 }

--- a/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmMethodHandler.java
+++ b/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmMethodHandler.java
@@ -74,7 +74,7 @@ public class KmMethodHandler implements MethodCallHandler {
                     result.error(ERROR, "appId is missing", null);
                     return;
                 }
-
+                user.setPlatform(User.Platform.FLUTTER.getValue());
                 Kommunicate.login(context, user, new KMLoginHandler() {
                     @Override
                     public void onSuccess(RegistrationResponse registrationResponse, Context context) {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -35,7 +35,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.kommunicate.app"
         minSdkVersion 16
-        targetSdkVersion 31
+        targetSdkVersion 30
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,34 @@
          In most cases you can leave this as-is, but you if you want to provide
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
+         <uses-permission
+        android:name="android.permission.CAMERA"
+        tools:node="merge" />
+
+    <!--Storage Permission required for API >= 33 -->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+
+
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32"
+        tools:ignore="ScopedStorage"
+        tools:node="merge" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32"
+        tools:node="merge" />
+    <uses-permission
+        android:name="android.permission.RECORD_AUDIO"
+        tools:node="merge" />
+    <uses-permission
+        android:name="android.permission.ACCESS_COARSE_LOCATION"
+        tools:node="merge" />
+    <uses-permission
+        android:name="android.permission.ACCESS_FINE_LOCATION"
+        tools:node="merge" />
     <application
         android:name="io.flutter.app.FlutterApplication"
         android:icon="@mipmap/ic_launcher"

--- a/ios/kommunicate_flutter.podspec
+++ b/ios/kommunicate_flutter.podspec
@@ -17,7 +17,7 @@ Flutter plugin for Kommunicate live chat.
 
   s.dependency 'Flutter'
   s.swift_version = '5.1'
-  s.dependency 'Kommunicate', '~> 6.7.4'
+  s.dependency 'Kommunicate', '~> 6.7.8'
 
   s.ios.deployment_target = '12.0'
 end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kommunicate_flutter
 description: Flutter plugin for Kommunicate live chat. Kommunicate provides open source live chat SDK in android. The Kommunicate SDK is flexible, lightweight and easily integrable.
-version: 1.5.1
+version: 1.5.5
 homepage: https://kommunicate.io
 
 environment:


### PR DESCRIPTION
## 1.5.5
- Added support to send platform flag for analytics
- Added logout option on conversation screen - Android
- Handle Notifications from FCM directly - Android
- Added support for AES256 encryption and decryption - Android
- Added fix for API <= 19. Current min SDK version is still 16. All bugs have been fixed for lower SDK versions.
- Added Edit Message Text box Customization - "messageEditTextBackgroundColor" - Android
- Added support to set Custom bot name through Chat Context
- Added Support for Android API 33 
- Threads optimized and multiple crash fixed - Android
- Added Support for App Extension - iOS
- Fixed add contact permission to info.list issue when app is submitted on App Store - iOS
- Added Button to create new conversation on conversation list screen - iOS 