### PR TITLE
[CM-1370] - Support for custom toolbar subtitle - Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,5 +38,5 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    api 'io.kommunicate.sdk:kommunicateui:2.6.8'
+    api 'io.kommunicate.sdk:kommunicateui:2.6.9'
 }

--- a/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmMethodHandler.java
+++ b/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmMethodHandler.java
@@ -403,6 +403,23 @@ public class KmMethodHandler implements MethodCallHandler {
             } catch(Exception e) {
                 result.error(ERROR, e.toString(), null);
             }
+        } else if(call.method.equals("createCustomToolbar")) {
+            try {
+                JSONObject toolbarObject = new JSONObject(call.arguments.toString());
+                KmConversationInfoSetting kmConversationInfoSetting = KmConversationInfoSetting.getInstance(context);
+                if (toolbarObject.has("show")) {
+                    kmConversationInfoSetting.enableCustomToolbarSubtitleDesign(Boolean.valueOf(toolbarObject.get("show").toString()));
+                }
+                if (toolbarObject.has("experienceText") && !TextUtils.isEmpty(toolbarObject.get("experienceText").toString())) {
+                    kmConversationInfoSetting.setToolbarAgentExperience(toolbarObject.get("experienceText").toString());
+
+                }
+                if (toolbarObject.has("rating") && !TextUtils.isEmpty(toolbarObject.get("rating").toString())) {
+                    kmConversationInfoSetting.setToolbarSubtitleRating(Float.valueOf(toolbarObject.get("rating").toString()));
+                }
+            } catch(Exception e) {
+                    result.error(ERROR, e.toString(), null);
+                }
         }
         else {
             result.notImplemented();

--- a/lib/kommunicate_flutter.dart
+++ b/lib/kommunicate_flutter.dart
@@ -73,4 +73,7 @@ class KommunicateFlutterPlugin {
   static Future<dynamic> closeConversationScreen() async {
     return await _channel.invokeMethod('closeConversationScreen');
   }
+  static Future<dynamic> createCustomToolbar(dynamic toolbarObject) async {
+    return await _channel.invokeMethod('createCustomToolbar', jsonEncode(toolbarObject));
+  }
 }


### PR DESCRIPTION
## Summary:
-Added support for custom toolbar in which user can set agent experience and agent rating

## Code:
```dart
KommunicateFlutterPlugin.createCustomToolbar({
                      "show": true,
                      "experienceText": "7 Years Experience",
                      "rating": 4.5
                    });
```

## Screenshot
![image](https://user-images.githubusercontent.com/121423566/231797977-c5511392-0916-44b1-ba18-4be93bf42e51.png)
