### PR TITLE
[CM-1283] Passed platform flag in login api call 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- Added platform flag.
+
 ## 1.7.0
 - Added support for API Suggestions
 - Fixed visibility of startNewConversation button

--- a/ios/Classes/SwiftKommunicateFlutterPlugin.swift
+++ b/ios/Classes/SwiftKommunicateFlutterPlugin.swift
@@ -66,6 +66,7 @@ public class SwiftKommunicateFlutterPlugin: NSObject, FlutterPlugin, KMPreChatFo
                 let jsonString = String(bytes: jsonData, encoding: .utf8)
                 let kmUser = KMUser(jsonString: jsonString)
                 kmUser?.applicationId = userDict["appId"] as? String
+                kmUser?.platform = NSNumber(value: PLATFORM_FLUTTER.rawValue)
                 
                 Kommunicate.registerUser(kmUser!, completion: {
                     response, error in
@@ -88,6 +89,7 @@ public class SwiftKommunicateFlutterPlugin: NSObject, FlutterPlugin, KMPreChatFo
             let kmUser = KMUser()
             kmUser.userId = Kommunicate.randomId()
             kmUser.applicationId = appId
+            kmUser.platform = NSNumber(value: PLATFORM_FLUTTER.rawValue)
             
             Kommunicate.registerUser(kmUser, completion: {
                 response, error in


### PR DESCRIPTION
## Summary 
- Passed platform flag through the KMUser at the time login api is called.