### PR TITLE
[CM-1798] Event Trigger via message meta data bug 

### DIFF
--- a/ios/Classes/SwiftKommunicateFlutterPlugin.swift
+++ b/ios/Classes/SwiftKommunicateFlutterPlugin.swift
@@ -295,10 +295,8 @@ public class SwiftKommunicateFlutterPlugin: NSObject, FlutterPlugin, KMPreChatFo
                     conversationInfo = [SwiftKommunicateFlutterPlugin.KM_CONVERSATION_METADATA: jsonObj["conversationInfo"] as Any]
                 }
                 
-                if let messageMetadataStr = (jsonObj["messageMetadata"] as? String)?.data(using: .utf8) {
-                    if let messageMetadataDict = try JSONSerialization.jsonObject(with: messageMetadataStr, options : .allowFragments) as? Dictionary<String,Any> {
-                        Kommunicate.defaultConfiguration.messageMetadata = messageMetadataDict
-                    }
+                if let messageMetadataStr = jsonObj["messageMetadata"] as? [String : Any] {
+                        Kommunicate.defaultConfiguration.messageMetadata = messageMetadataStr
                 }
                 
                 let agentIds = jsonObj["agentIds"] as? [String]


### PR DESCRIPTION
## Summary 
- Fixed Message Metadata typeCasting in iOS Side. 
- Need to pass the data in object format
## Code 
```
dynamic metadataObject = {'CUSTOM_WELCOME_EVENT' : 'welcome_sti'};
dynamic conversationObject = {'appId': <YOUR-APP-ID>, 'messageMetadata': metadataObject}; 
/// user can pass this conversation object in Build conversation function
```
