### PR TITLE
[CM-1841] Update function for register user as visitor in iOS

### DIFF
--- a/ios/Classes/SwiftKommunicateFlutterPlugin.swift
+++ b/ios/Classes/SwiftKommunicateFlutterPlugin.swift
@@ -86,12 +86,11 @@ public class SwiftKommunicateFlutterPlugin: NSObject, FlutterPlugin, KMPreChatFo
             }
             
             Kommunicate.setup(applicationId: appId)
-            let kmUser = KMUser()
-            kmUser.userId = Kommunicate.randomId()
+            let kmUser = Kommunicate.createVisitorUser()
             kmUser.applicationId = appId
             kmUser.platform = NSNumber(value: PLATFORM_FLUTTER.rawValue)
             
-            Kommunicate.registerUser(kmUser, completion: {
+            Kommunicate.registerUserAsVistor (kmUser, completion: {
                 response, error in
                 guard error == nil else {
                     self.sendErrorResultWithCallback(result: result, message: error!.localizedDescription)


### PR DESCRIPTION
## Summary 
- Updated `Kommunicate.registerUser ` with `Kommunicate.registerUserAsVistor `.

## Verified 
- [x] pseudoname Flag is reflecting.
<img width="385" alt="Screenshot 2024-02-02 at 1 03 22 PM" src="https://github.com/Kommunicate-io/Kommunicate-Flutter-Plugin/assets/139110221/39902ce7-4b35-434a-aa11-d6752936d503">
