### PR TITLE
[CM-1889] Added support for AGP 8.X.X

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,7 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+    namespace "io.kommunicate.kommunicate_flutter_plugin"
 }
 
 dependencies {


### PR DESCRIPTION
## Summary

In the native Android side , while upgrading the AGP version to 8.X.X, we can just upgrade our project via AGP upgrade assitant but for the hybrid platforms, we need to have the namespace inside the module's build file to upgrade the project to 8.X.X 

## How was the code tested ?

- Verified that the project is working for AGP < 8.X.X and >= AGP 8.0.0
- Verified by upgrading and downgrading the AGP versions multiple time to verify the backward compatibility