### PR TITLE
[CM-2026] Added Support for EU Servers 

### DIFF
--- a/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmMethodHandler.java
+++ b/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmMethodHandler.java
@@ -56,7 +56,6 @@ public class KmMethodHandler implements MethodCallHandler {
     private static final String ERROR = "Error";
     private Activity context;
     private MethodChannel methodChannel;
-    private KMServerConfiguration serverConfig  = KMServerConfiguration.DEFAULTCONFIGURATION;
     public KmMethodHandler(Activity context) {
         this.context = context;
     }
@@ -69,13 +68,10 @@ public class KmMethodHandler implements MethodCallHandler {
             try {
                 String serverConfigText = (String) call.arguments();
                 if (!TextUtils.isEmpty(serverConfigText)) {
-                    switch (serverConfigText) {
-                        case "euConfiguration":
-                            this.serverConfig = KMServerConfiguration.EUCONFIGURATION;
-                            Kommunicate.setServerConfiguration(context, KMServerConfiguration.DEFAULTCONFIGURATION);
-                            break;
-                        default:
-                            result.error(ERROR, "It only supports `euConfiguration` for now.", null);
+                    if (serverConfigText == "euConfiguration") {
+                        Kommunicate.setServerConfiguration(context, KMServerConfiguration.EUCONFIGURATION);
+                    } else {
+                        Kommunicate.setServerConfiguration(context, KMServerConfiguration.DEFAULTCONFIGURATION);
                     }
                 } else {
                     result.error(ERROR, "Invalid Server Config", null);
@@ -92,9 +88,6 @@ public class KmMethodHandler implements MethodCallHandler {
                 KMUser user = (KMUser) GsonUtils.getObjectFromJson(userObject.toString(), KMUser.class);
 
                 if (userObject.has("appId") && !TextUtils.isEmpty(userObject.get("appId").toString())) {
-                    if (serverConfig == KMServerConfiguration.EUCONFIGURATION) {
-                        Kommunicate.setServerConfiguration(context, serverConfig);
-                    }
                     Kommunicate.init(context, userObject.get("appId").toString());
                 } else {
                     result.error(ERROR, "appId is missing", null);
@@ -180,9 +173,6 @@ public class KmMethodHandler implements MethodCallHandler {
             try {
             String appId = (String) call.arguments();
             if (!TextUtils.isEmpty(appId)) {
-                if (serverConfig == KMServerConfiguration.EUCONFIGURATION) {
-                    Kommunicate.setServerConfiguration(context, serverConfig);
-                }
                 Kommunicate.init(context, appId);
             } else {
                 result.error(ERROR, "appId is missing", null);

--- a/ios/Classes/SwiftKommunicateFlutterPlugin.swift
+++ b/ios/Classes/SwiftKommunicateFlutterPlugin.swift
@@ -55,6 +55,7 @@ public class SwiftKommunicateFlutterPlugin: NSObject, FlutterPlugin, KMPreChatFo
             switch serverConfig {
                 case "euConfiguration":
                     self.serverConfig = .euConfiguration
+                    Kommunicate.setServerConfiguration(.euConfiguration)
                 default:
                     self.sendErrorResultWithCallback(result: result, message: "It only supports `euConfiguration` for now.")
             }

--- a/ios/Classes/SwiftKommunicateFlutterPlugin.swift
+++ b/ios/Classes/SwiftKommunicateFlutterPlugin.swift
@@ -18,7 +18,6 @@ public class SwiftKommunicateFlutterPlugin: NSObject, FlutterPlugin, KMPreChatFo
     var conversationTitle: String? = nil;
     var conversationInfo: [AnyHashable: Any]? = nil;
     var teamId: String? = nil;
-    var serverConfig: KMServerConfiguration = .defaultConfiguration;
     static let KM_CONVERSATION_METADATA: String = "conversationMetadata";
     static let CLIENT_CONVERSATION_ID: String = "clientConversationId";
     static let CONVERSATION_ID: String = "conversationId";
@@ -52,12 +51,10 @@ public class SwiftKommunicateFlutterPlugin: NSObject, FlutterPlugin, KMPreChatFo
                 self.sendErrorResultWithCallback(result: result, message: "Invalid Server Config")
                 return
             }
-            switch serverConfig {
-                case "euConfiguration":
-                    self.serverConfig = .euConfiguration
-                    Kommunicate.setServerConfiguration(.euConfiguration)
-                default:
-                    self.sendErrorResultWithCallback(result: result, message: "It only supports `euConfiguration` for now.")
+            if (serverConfig == "euConfiguration") {
+                Kommunicate.setServerConfiguration(.euConfiguration)
+            } else {
+                Kommunicate.setServerConfiguration(.defaultConfiguration)
             }
         } else if(call.method == "isLoggedIn") {
             result(Kommunicate.isLoggedIn)
@@ -70,9 +67,6 @@ public class SwiftKommunicateFlutterPlugin: NSObject, FlutterPlugin, KMPreChatFo
             guard let appId = userDict["appId"] as? String, !appId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
                 self.sendErrorResultWithCallback(result: result, message: "Invalid or missing appId")
                 return
-            }
-            if serverConfig == .euConfiguration {
-                Kommunicate.setServerConfiguration(.euConfiguration)
             }
             Kommunicate.setup(applicationId: appId)
             userDict.removeValue(forKey: "appId")
@@ -99,9 +93,6 @@ public class SwiftKommunicateFlutterPlugin: NSObject, FlutterPlugin, KMPreChatFo
             guard let appId = call.arguments as? String, !appId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
                 self.sendErrorResultWithCallback(result: result, message: "Invalid or missing appId")
                 return
-            }
-            if serverConfig == .euConfiguration {
-                Kommunicate.setServerConfiguration(.euConfiguration)
             }
             Kommunicate.setup(applicationId: appId)
             let kmUser = Kommunicate.createVisitorUser()
@@ -340,9 +331,6 @@ public class SwiftKommunicateFlutterPlugin: NSObject, FlutterPlugin, KMPreChatFo
                 
                 self.agentIds = agentIds
                 self.botIds = botIds
-                if serverConfig == .euConfiguration {
-                    Kommunicate.setServerConfiguration(.euConfiguration)
-                }
                 if Kommunicate.isLoggedIn{
                     self.handleCreateConversation()
                 }else{
@@ -573,9 +561,6 @@ public class SwiftKommunicateFlutterPlugin: NSObject, FlutterPlugin, KMPreChatFo
         
         kmUser.contactNumber = phoneNumber
         kmUser.displayName = name
-        if serverConfig == .euConfiguration {
-            Kommunicate.setServerConfiguration(.euConfiguration)
-        }
         Kommunicate.setup(applicationId: applicationKey)
         Kommunicate.registerUser(kmUser, completion:{
             response, error in

--- a/lib/kommunicate_flutter.dart
+++ b/lib/kommunicate_flutter.dart
@@ -100,4 +100,7 @@ class KommunicateFlutterPlugin {
   static Future<dynamic> hideAssigneeStatus(bool hide) async {
     return await _channel.invokeMethod('hideAssigneeStatus', hide);
   }
+  static Future<dynamic> setServerConfiguration(String serverName) async {
+    return await _channel.invokeListMethod('setServerConfiguration', serverName);
+  }
 }


### PR DESCRIPTION
## Summary
- Added Support of changing server config.
```
KommunicateFlutterPlugin.setServerConfiguration("euConfiguration");
```
- To use this need to add this before using any "`Login as Visitor`, `Login User` or `Build conversation`" in Android.
- To use this iOS side need to add the configuration at `didFinishLaunchingWithOptions` and before any of these "`Login as Visitor`, `Login User` or `Build conversation`". (Reason: when the app is Closed and reopened at that time the server got reset to default. To overcome the issue we can add the config in AppDelegate `didFinishLaunchingWithOptions `.)
- After Logout it's necessary to set server again before performing  "`Login as Visitor`, `Login User` or `Build conversation`"
- Updated the deprecated function in iOS. 