### PR TITLE
Fixed Android Chat Context issue

### DIFF
--- a/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmMethodHandler.java
+++ b/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmMethodHandler.java
@@ -201,6 +201,9 @@ public class KmMethodHandler implements MethodCallHandler {
                 result.error(ERROR, e.toString(), null);
             }
         } else if (call.method.equals("openConversations")) {
+            if (!Kommunicate.isLoggedIn(context)) { 
+                result.error(ERROR, "User is not logged in. Please log in to continue.", null); 
+            }
             Kommunicate.openConversation(context, new KmCallback() {
                 @Override
                 public void onSuccess(Object message) {
@@ -260,6 +263,9 @@ public class KmMethodHandler implements MethodCallHandler {
             }
         } else if (call.method.equals("openParticularConversation")) {
             try {
+                if (!Kommunicate.isLoggedIn(context)) { 
+                    result.error(ERROR, "User is not logged in. Please log in to continue.", null); 
+                }
                 final String clientConversationId = (String) call.arguments;
                 if (TextUtils.isEmpty(clientConversationId)) {
                     result.error(ERROR, "Invalid or empty clientConversationId", null);
@@ -331,6 +337,11 @@ public class KmMethodHandler implements MethodCallHandler {
                 KmConversationBuilder conversationBuilder = (KmConversationBuilder) GsonUtils.getObjectFromJson(conversationObject.toString(), KmConversationBuilder.class);
                 conversationBuilder.setContext(context);
 
+                if (conversationObject.has("appId")) {
+                    Kommunicate.init(context, conversationObject.get("appId").toString());
+                } else {
+                    Kommunicate.isLoggedIn(context);
+                }
                 if (!conversationObject.has("isSingleConversation")) {
                     conversationBuilder.setSingleConversation(true);
                 }


### PR DESCRIPTION
## Summary 
- Added `Kommunicate.isLoggedIn(context)` check in `openConversations`, `openParticularConversation` and `buildConversation`
- Also added init function in `buildConversation ` to set the context if appID is present in object.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error handling: Users attempting to access conversations without being logged in now receive a clear message.
  - Improved conversation initialization: Sessions now auto-configure when the necessary identifier is available, ensuring smoother functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->