### PR TITLE
[CM-2019] LoginAsVIsitor is not setting Plaform in Flutter Android | Flutter Android  

### DIFF
--- a/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmMethodHandler.java
+++ b/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmMethodHandler.java
@@ -186,7 +186,7 @@ public class KmMethodHandler implements MethodCallHandler {
                     return;
                 }
 
-                Kommunicate.loginAsVisitor(context, new KMLoginHandler() {
+                Kommunicate.loginAsVisitor(context, User.Platform.FLUTTER, new KMLoginHandler() {
                     @Override
                     public void onSuccess(RegistrationResponse registrationResponse, Context context) {
                         result.success(GsonUtils.getJsonFromObject(registrationResponse, RegistrationResponse.class));


### PR DESCRIPTION
## Summary 
- Added Platform in login as visitor Function to pass the Flutter platform in registration time. 
- Other Function already includes Platform Flutter at login time. 