### PR TITLE
[CM-2366] Fix Flutter Plugin Function deprecation in 3.29.0 | Flutter SDK

### DIFF
--- a/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmMethodHandler.java
+++ b/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmMethodHandler.java
@@ -12,7 +12,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 import io.kommunicate.KMServerConfiguration;
 import io.kommunicate.KmConversationBuilder;
 import io.kommunicate.KmSettings;

--- a/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KommunicateFlutterPlugin.java
+++ b/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KommunicateFlutterPlugin.java
@@ -7,55 +7,68 @@ import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodChannel;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
-        public class KommunicateFlutterPlugin implements FlutterPlugin, ActivityAware  {
+public class KommunicateFlutterPlugin implements FlutterPlugin, ActivityAware {
 
-            private MethodChannel methodChannel;
-            private BinaryMessenger binaryMessenger;
-            private KmEventListener kmEventListener;
-            public static void registerWith(Registrar registrar) {
-                final MethodChannel channel = new MethodChannel(registrar.messenger(), "kommunicate_flutter");
-                channel.setMethodCallHandler(new KmMethodHandler(registrar.activity()));
-                new KmEventListener().register(channel);
-            }
+    private MethodChannel methodChannel;
+    private BinaryMessenger binaryMessenger;
+    private KmEventListener kmEventListener;
+    private Activity activity;
 
-            public void setupChannel(Activity context) {
-                methodChannel = new MethodChannel(binaryMessenger, "kommunicate_flutter");
-                methodChannel.setMethodCallHandler(new KmMethodHandler(context));
-                kmEventListener = new KmEventListener();
-                kmEventListener.register(methodChannel);                
-            }
+    // Remove the old registerWith method
+    // public static void registerWith(Registrar registrar) {
+    //     final MethodChannel channel = new MethodChannel(registrar.messenger(), "kommunicate_flutter");
+    //     channel.setMethodCallHandler(new KmMethodHandler(registrar.activity()));
+    //     new KmEventListener().register(channel);
+    // }
 
-            private void destroyChannel() {
-                methodChannel.setMethodCallHandler(null);
-                methodChannel = null;
-                kmEventListener.unregister(); 
-            }
+    public void setupChannel(Activity context) {
+        methodChannel = new MethodChannel(binaryMessenger, "kommunicate_flutter");
+        methodChannel.setMethodCallHandler(new KmMethodHandler(context));
+        kmEventListener = new KmEventListener();
+        kmEventListener.register(methodChannel);
+    }
 
-            @Override
-            public void onAttachedToEngine(FlutterPlugin.FlutterPluginBinding binding) {
-                binaryMessenger = binding.getBinaryMessenger();
-            }
-            @Override
-            public void onDetachedFromEngine(FlutterPlugin.FlutterPluginBinding binding) {
-                destroyChannel();
-            }
+    private void destroyChannel() {
+        if (methodChannel != null) {
+            methodChannel.setMethodCallHandler(null);
+            methodChannel = null;
+        }
+        if (kmEventListener != null) {
+            kmEventListener.unregister();
+            kmEventListener = null;
+        }
+    }
 
-            @Override
-            public void onAttachedToActivity(ActivityPluginBinding activityPluginBinding) {
-                setupChannel(activityPluginBinding.getActivity());
-            }
+    @Override
+    public void onAttachedToEngine(FlutterPlugin.FlutterPluginBinding binding) {
+        binaryMessenger = binding.getBinaryMessenger();
+    }
 
-            @Override
-            public void onDetachedFromActivityForConfigChanges() {
-            }
+    @Override
+    public void onDetachedFromEngine(FlutterPlugin.FlutterPluginBinding binding) {
+        destroyChannel();
+    }
 
-            @Override
-            public void onReattachedToActivityForConfigChanges(ActivityPluginBinding activityPluginBinding) {
-            }
+    @Override
+    public void onAttachedToActivity(ActivityPluginBinding activityPluginBinding) {
+        activity = activityPluginBinding.getActivity();
+        setupChannel(activity);
+    }
 
-            @Override
-            public void onDetachedFromActivity() {
-            }
+    @Override
+    public void onDetachedFromActivityForConfigChanges() {
+        onDetachedFromActivity();
+    }
+
+    @Override
+    public void onReattachedToActivityForConfigChanges(ActivityPluginBinding activityPluginBinding) {
+        onAttachedToActivity(activityPluginBinding);
+    }
+
+    @Override
+    public void onDetachedFromActivity() {
+        destroyChannel();
+        activity = null;
+    }
 }


### PR DESCRIPTION
## Summary 
- Removed the registerWith method as it's no longer required for Flutter versions 1.12 and above (our minimum supported version).
- Refactored the implementation of `onDetachedFromActivityForConfigChanges`, `onReattachedToActivityForConfigChanges`, and `onDetachedFromActivity` to align with the latest Flutter plugin lifecycle methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined plugin lifecycle handling for smoother integration and configuration changes.
- **Bug Fixes**
  - Enhanced cleanup processes with added safety checks to prevent potential runtime issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->