### PR TITLE
Add support for compileSdkVersion as per client project with default value of 34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.8
+- Added initialization code for Android and iOS.
+
 ## 2.0.7
 ## Android 
 - Toast Message Bug Fix.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Refer to the official docs here: https://docs.kommunicate.io/docs/flutter-instal
 ```
 dependencies:
   //other dependencies
-  kommunicate_flutter: ^2.0.7
+  kommunicate_flutter: ^2.0.8
 ```
 
 2. Install the package as below:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,15 +25,14 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 33
-
+    def sdk = rootProject.hasProperty("compileSdkVersion") ? rootProject.compileSdkVersion.toInteger() : 34
+    compileSdkVersion sdk
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
+        targetSdkVersion sdk
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
-    lintOptions {
-        disable 'InvalidPackage'
-    }
+    lintOptions { disable 'InvalidPackage' }
     namespace "io.kommunicate.kommunicate_flutter_plugin"
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,10 +25,11 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    def sdk = rootProject.hasProperty("compileSdkVersion") ? rootProject.compileSdkVersion.toInteger() : 34
+    def sdkProp = rootProject.findProperty('compileSdkVersion')
+    def sdk = (sdkProp instanceof Number) ? (sdkProp as Integer) : Integer.parseInt((sdkProp ?: 34).toString())
     compileSdkVersion sdk
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 16
         targetSdkVersion sdk
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmMethodHandler.java
+++ b/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmMethodHandler.java
@@ -69,9 +69,14 @@ public class KmMethodHandler implements MethodCallHandler {
         } else if (call.method.equals("init")) {
             try {
                 final String initAppID = (String) call.arguments();
+                if (TextUtils.isEmpty(initAppID)) {
+                    result.error(ERROR, "appId is missing", null);
+                    return;
+                }
                 Kommunicate.init(context, initAppID);
+                result.success(null); // complete Future<void>
             } catch (Exception e) {
-                result.error(ERROR, e.getMessage(), null);
+                result.error(ERROR, e.toString(), null);
             }
         } else if (call.method.equals("setServerConfiguration")) {
             try {

--- a/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmMethodHandler.java
+++ b/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmMethodHandler.java
@@ -74,7 +74,7 @@ public class KmMethodHandler implements MethodCallHandler {
                     return;
                 }
                 Kommunicate.init(context, initAppID);
-                result.success(null); // complete Future<void>
+                result.success(null);
             } catch (Exception e) {
                 result.error(ERROR, e.toString(), null);
             }

--- a/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmMethodHandler.java
+++ b/android/src/main/java/io/kommunicate/kommunicate_flutter_plugin/KmMethodHandler.java
@@ -66,6 +66,13 @@ public class KmMethodHandler implements MethodCallHandler {
     public void onMethodCall(MethodCall call, final Result result) {
         if (call.method.equals("getPlatformVersion")) {
             result.success("Android " + android.os.Build.VERSION.RELEASE);
+        } else if (call.method.equals("init")) {
+            try {
+                final String initAppID = (String) call.arguments();
+                Kommunicate.init(context, initAppID);
+            } catch (Exception e) {
+                result.error(ERROR, e.getMessage(), null);
+            }
         } else if (call.method.equals("setServerConfiguration")) {
             try {
                 String serverConfigText = (String) call.arguments();

--- a/example/lib/home.dart
+++ b/example/lib/home.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:kommunicate_flutter/kommunicate_flutter.dart';
+import 'package:kommunicate_flutter_plugin_example/AppConfig.dart';
 import 'dart:io' show Platform;
 import 'main.dart';
 
@@ -17,6 +18,11 @@ class HomePageState extends State<HomePage> {
   void initState() {
     try {} catch (e) {}
     super.initState();
+    KommunicateFlutterPlugin.init(AppConfig.APP_ID).then((value) {
+      print("Initialization successful : " + value.toString());
+    }).catchError((error) {
+      print("Initialization error occurred : " + error.toString());
+    });
   }
 
   @override

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -43,6 +43,11 @@ class _MyAppState extends State<MyApp> {
     });
     }
     super.initState();
+    KommunicateFlutterPlugin.init(AppConfig.APP_ID).then((value) {
+      print("Initialization successful : " + value.toString());
+    }).catchError((error) {
+      print("Initialization error occurred : " + error.toString());
+    });
   }
 
   @override

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -45,10 +45,10 @@ packages:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: d57953e10f9f8327ce64a508a355f0b1ec902193f66288e8cb5070e7c47eeb2d
+      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.6"
+    version: "1.0.8"
   fake_async:
     dependency: transitive
     description:
@@ -86,7 +86,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.7"
+    version: "2.0.8"
   leak_tracker:
     dependency: transitive
     description:

--- a/ios/Classes/SwiftKommunicateFlutterPlugin.swift
+++ b/ios/Classes/SwiftKommunicateFlutterPlugin.swift
@@ -56,6 +56,14 @@ public class SwiftKommunicateFlutterPlugin: NSObject, FlutterPlugin, KMPreChatFo
             } else {
                 Kommunicate.setServerConfiguration(.defaultConfiguration)
             }
+        } else if(call.method == "init") {
+            guard let appId = call.arguments as? String, !appId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                self.sendErrorResultWithCallback(result: result, message: "Invalid or missing appId")
+                return
+            }
+            Kommunicate.setup(applicationId: appId)
+            self.appId = appId
+            self.sendSuccessResultWithCallback(result: result, message: "Successfully initialized with appId: \(appId)")
         } else if(call.method == "isLoggedIn") {
             result(Kommunicate.isLoggedIn)
         } else if(call.method == "login") {

--- a/ios/Classes/SwiftKommunicateFlutterPlugin.swift
+++ b/ios/Classes/SwiftKommunicateFlutterPlugin.swift
@@ -57,10 +57,18 @@ public class SwiftKommunicateFlutterPlugin: NSObject, FlutterPlugin, KMPreChatFo
                 Kommunicate.setServerConfiguration(.defaultConfiguration)
             }
         } else if(call.method == "init") {
-            guard let appId = call.arguments as? String, !appId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-                self.sendErrorResultWithCallback(result: result, message: "Invalid or missing appId")
+            guard let rawAppId = call.arguments as? String else {
+                self.sendErrorResultWithCallback(result: result, message: "Missing appId")
                 return
             }
+
+            let appId = rawAppId.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            guard !appId.isEmpty else {
+                self.sendErrorResultWithCallback(result: result, message: "Invalid or empty appId")
+                return
+            }
+
             Kommunicate.setup(applicationId: appId)
             self.appId = appId
             self.sendSuccessResultWithCallback(result: result, message: "Successfully initialized with appId: \(appId)")

--- a/lib/kommunicate_flutter.dart
+++ b/lib/kommunicate_flutter.dart
@@ -13,6 +13,10 @@ class KommunicateFlutterPlugin {
     return version;
   }
 
+  static Future<dynamic> init(String appId) async {
+    return await _channel.invokeMethod('init', appId);
+  }
+
   static Future<dynamic> buildConversation(dynamic conversationObject) async {
     if (kIsWeb) {
     return await _channel.invokeMethod('buildConversation', jsonEncode(conversationObject));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kommunicate_flutter
 description: Flexible, lightweight, and easily integrable Flutter SDK for Kommunicate AI chatbot & Live Chat.
-version: 2.0.7
+version: 2.0.8
 homepage: https://kommunicate.io
 
 environment:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public plugin init API to initialize the SDK with an app ID (validates input and reports errors if missing).

* **Chores**
  * Android compile/target SDK now follows a dynamic project property for better platform alignment; min SDK unchanged.
  * Simplified Android lint configuration to reduce build noise.

* **iOS**
  * Native init handling added to invoke SDK setup and return success or error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->